### PR TITLE
Fix </em> and </strong> conversions

### DIFF
--- a/parsers/forkedMagicalParsers.js
+++ b/parsers/forkedMagicalParsers.js
@@ -6,6 +6,8 @@ import util from 'util';
 
 export function fixBadHTML(html) {
   html = html.replace(/(\r?\n){2}/g, '<p></p>');
+  html = html.replace(/ <\/em>/g, '</em> ');
+  html = html.replace(/ <\/strong>/g, '</strong> ');
   return html;
 }
 


### PR DESCRIPTION
The problem was text like
```
<em>more </em>effective
```
translated into
```
_more _effective
```
which stringify happily escaped for us, and which isn't handled by govspeak (maybe not valid markdown at all?). 

The solution is to move the space from before closing tag to after - and everything magically works. 