### PR TITLE
add images

### DIFF
--- a/converters/processPage.js
+++ b/converters/processPage.js
@@ -16,6 +16,7 @@ import {
 import { cleanupParagraphAndHeaderTags } from '../parsers/cleanupWordpressTags';
 import {
   fixLinkButtons, fixAccordions, fixYoutubeEmbeddings, fixHighlights, fixActionPrompt,
+  findImageData, fixImages,
 } from '../parsers/handleWordpressComponents';
 import { processImage, processImages } from './processImages';
 
@@ -31,9 +32,11 @@ function parseMarkdown(postData) {
       })
       .use(fixCodeBlocks)
       .use(fixEmbeds)
+      .use(findImageData)
       .use(rehype2remark)
       .use(cleanupShortcodes)
       .use(fixLinkButtons)
+      .use(fixImages)
       .use(fixAccordions)
       .use(fixActionPrompt)
       .use(fixYoutubeEmbeddings)

--- a/parsers/handleWordpressComponents.js
+++ b/parsers/handleWordpressComponents.js
@@ -74,13 +74,13 @@ export function fixAccordions() {
   };
 }
 
-const findCaptionText = (figureCaption, key) => {
+const findCaptionText = (figureCaptionNodes) => {
   let figCaptionValue = '';
-  const nestedFigCap = figureCaption.filter((o) => o.type === key);
-  if (nestedFigCap.length > 0) {
-    figCaptionValue = nestedFigCap[0].value;
+  const hasFigCapText = figureCaptionNodes.filter((o) => o.type === 'text');
+  if (hasFigCapText.length > 0) {
+    figCaptionValue = hasFigCapText[0].value;
   } else {
-    const string = findCaptionText(figureCaption[0].children, key);
+    const string = findCaptionText(figureCaptionNodes[0].children);
     if (string) {
       figCaptionValue += string;
     }
@@ -92,15 +92,14 @@ export function findImageData() {
   return (tree) => {
     visit(tree, (node) => node.type === 'element' && node.children.some((n) => n.tagName === 'img'), (node) => {
       const arrayOfImageData = node.children.filter((imageData) => imageData.tagName === 'img');
-      const { src } = arrayOfImageData[0].properties;
-      const { alt } = arrayOfImageData[0].properties;
+      const { src, alt } = arrayOfImageData[0].properties;
 
-      const figureCaption = node.children.filter((element) => element.tagName === 'figcaption');
+      const figureCaptionNodes = node.children.filter((element) => element.tagName === 'figcaption');
 
       let captionText = '';
-      if (figureCaption.length > 0) {
-        captionText = findCaptionText(figureCaption, 'text');
-      } else captionText = '';
+      if (figureCaptionNodes.length > 0) {
+        captionText = findCaptionText(figureCaptionNodes);
+      }
 
       const govSpeakImageData = `$Alt\n${alt}\n$EndAlt\n$URL\n${src}\n$EndURL\n$Caption\n${captionText}\n$EndCaption`;
 


### PR DESCRIPTION
### Context 
Images needed to be converted to govspeak in order to render on the ecf railsapp.

### Changes proposed in this pull request
Adding functions that retrieve and convert the alt, src and url for images hosted on the WP site. 

### Guidance to review 
The _findCaptionText_ function is required to find captions that are nested within the figcaption. It runs recursively until it finds the value as not all values can be found at the same point in the nesting. 
The _fixImages_ function has been added as the \n gets replaced with whitespace in the initial conversion of the imageData. A new line after $Figure and before the $EndFigure are required to work on the railsapp using the ECF-govspeak as it currently is. 

